### PR TITLE
Improve descriptor display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Second, you need to configure Jenkins:
 3. Go to the Job you want notifies the builds to Bitbucket.
 4. Click **Configure**.
 5. Click **Add post-build action**.
-6. Set the **Key** and **Secret** you previously created.
-7. Choose whether you want to notify the build status on Jenkins to Bitbucket.
+6. Select **Set build status on Bitbucket commit**.
+7. Set the **Key** and **Secret** you previously created.
+8. Choose whether you want to notify the build status on Jenkins to Bitbucket.
 
 ## Contributions
 

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -237,7 +237,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
 
         @Override
         public String getDisplayName() {
-            return "Bitbucket notify build status";
+            return "Set build status on Bitbucket commit";
         }
 
         public DescriptorImpl() {


### PR DESCRIPTION
Replace descriptor display name "Bitbucket notify build status" by
"Set build status on Bitbucket commit" because of consistency with
same functionality provided by the GitHub plugin for Jenkins.

https://github.com/jenkinsci/github-plugin