### PR TITLE
[JENKINS-32498] Fix problem fetching repo name from URI

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -173,8 +173,10 @@ public class BitbucketBuildStatusNotifier extends Notifier {
 
         // extract bitbucket user name and repository name from repo URI
         String repoUrl = urIish.getPath();
-
-        String repoName = repoUrl.substring(repoUrl.lastIndexOf("/") + 1, repoUrl.indexOf(".git"));
+        String repoName = repoUrl.substring(
+                repoUrl.lastIndexOf("/") + 1,
+                repoUrl.indexOf(".git") > -1 ? repoUrl.indexOf(".git") : repoUrl.length()
+        );
         if (repoName.isEmpty()) {
             throw new Exception("Bitbucket build notifier could not extract the repository name from the repository URL");
         }


### PR DESCRIPTION
Fix error [JENKINS-32498](https://issues.jenkins-ci.org/browse/JENKINS-32498) fetching repository name from URI, since URI must not end with ".git".