### PR TITLE
[Fix JENKINS-32940] Update bitbucket status resource if prev build wa…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/model/BitbucketBuildStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/model/BitbucketBuildStatus.java
@@ -50,4 +50,8 @@ public class BitbucketBuildStatus {
     public String getDescription() {
         return description;
     }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
 }


### PR DESCRIPTION
This fix two different problems as reported by the community:

1. If a build is manually aborted by the user in jenkins the build status in bitbucket remained `INPROGRESS` although the build was already finished. From now on build abortion the bitbucket build status will be set to `FAILED`.
2. If the previous build was aborted and the scm revision is the same for the previous and the current build then the bitbucket build status will be updated instead to create a new one.