### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -234,7 +234,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
 
     private void notifyBuildStatus(final AbstractBuild build, final BuildListener listener) throws Exception {
 
-        UsernamePasswordCredentials credentials = this.getCredentials(this.getCredentialsId(), build.getProject());
+        UsernamePasswordCredentials credentials = BitbucketBuildStatusNotifier.getCredentials(this.getCredentialsId(), build.getProject());
         List<BitbucketBuildStatusResource> buildStatusResources = this.createBuildStatusResources(build);
 
         AbstractBuild prevBuild = build.getPreviousBuild();
@@ -261,7 +261,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
 
             if (credentials == null) {
                 Job job = null;
-                credentials = this.getCredentials(this.getDescriptor().getGlobalCredentialsId(), job);
+                credentials = BitbucketBuildStatusNotifier.getCredentials(this.getDescriptor().getGlobalCredentialsId(), job);
             }
             if (credentials == null) {
                 throw new Exception("Credentials could not be found!");
@@ -383,6 +383,10 @@ public class BitbucketBuildStatusNotifier extends Notifier {
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         private String globalCredentialsId;
+        
+        public DescriptorImpl() {
+            load();
+        }
 
         public String getGlobalCredentialsId() {
             return globalCredentialsId;
@@ -395,10 +399,6 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         @Override
         public String getDisplayName() {
             return "Bitbucket notify build status";
-        }
-
-        public DescriptorImpl() {
-            load();
         }
 
         @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2209 - "static" members should be accessed statically. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2209

Please let me know if you have any questions.

Faisal Hameed