### PR TITLE
[FIXED JENKINS-34619] Add test results to build status in bitbucket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
       <artifactId>multiple-scms</artifactId>
       <version>0.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -24,6 +24,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
+import hudson.tasks.test.AbstractTestResultAction;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.LogTaskListener;
@@ -296,8 +297,14 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         String buildKey = DigestUtils.md5Hex(build.getProject().getFullDisplayName() + "#" + build.getNumber());
         String buildUrl = build.getProject().getAbsoluteUrl() + build.getNumber() + '/';
         String buildName = build.getProject().getFullDisplayName() + " #" + build.getNumber();
+        AbstractTestResultAction testResult = build.getAction(AbstractTestResultAction.class);
+        String description = "";
+        if (testResult != null) {
+            int passedCount = testResult.getTotalCount() - testResult.getFailCount();
+            description = passedCount + " of " + testResult.getTotalCount() + " tests passed";
+        }
 
-        return new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName);
+        return new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName, description);
     }
 
     private interface ScmAdapter {


### PR DESCRIPTION
Support reporting test results into bitbucket so that the reason for build failure can be seen at a glance from a pull request or branch.