### PR TITLE
Step definition for pipeline plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Third, you need to add the Bitbucket OAuth Consumer credentials. You have two wa
  4. Click **Add** button.
 7. Select the desired credentials.
 
-### Configure Jenkins to notify Bitbucket
+### Configure Jenkins to notify Bitbucket from a standard build
 
 Once you have configured the credentials, configure jenkins to notify Bitbucket.
 
@@ -81,6 +81,74 @@ Once you have configured the credentials, configure jenkins to notify Bitbucket.
 2. Click **Configure**.
 3. Select **Bitbucket notify build status**.
 4. Choose whether you want to notify the build status on Jenkins to Bitbucket.
+
+### Pipeline step to notify Bitbucket
+
+Once you have configured the credential, you can notify BitBucket from your Pipeline script through the `bitbucketStatusNotify` step.
+
+#### Usage
+
+The `bitbucketStatusNotify` step notifies the status of a build identified by a build key and build name to BitBucket.
+If `buildKey` and `buildName` parameters are not provided, a standard name will be assigned to the build (NameOfYourJob #numberOfBuild - eg. MyProject #32).
+When a `FAILED` status is sent to BitBucket, `bitbucketStatusNotify` throws an exception terminating your Pipeline.
+
+```groovy
+  ...
+  stage 'Build'
+    bitbucketStatusNotify(
+      buildState: 'INPROGRESS',
+      buildKey: 'build',
+      buildName: 'Build'
+    )
+    try {
+        myBuildFunction()
+        bitbucketStatusNotify(
+          buildState: 'SUCCESSFUL',
+          buildKey: 'build',
+          buildName: 'Build'
+        )
+    } catch(Exception e) {
+        bitbucketStatusNotify(
+          buildState: 'FAILED',
+          buildKey: 'build',
+          buildName: 'Build',
+          buildDescription: 'Something went wrong with build!'
+        )
+    }
+  stage 'Test'
+    bitbucketStatusNotify(
+      buildState: 'INPROGRESS',
+      buildKey: 'test',
+      buildName: 'Test'
+    )
+    try {
+        myTestFunction()
+        bitbucketStatusNotify(
+          buildState: 'SUCCESSFUL',
+          buildKey: 'test',
+          buildName: 'Test'
+        )
+    } catch(Exception e) {
+        bitbucketStatusNotify(
+          buildState: 'FAILED',
+          buildKey: 'test',
+          buildName: 'Test',
+          buildDescription: 'Something went wrong with tests!'
+        )
+    }
+  ...
+```
+
+#### API Summary
+
+Parameter:
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `buildState` | `"INPROGRESS"|"SUCCESSFUL"|"FAILED"` | no | The status of the current build phase
+| `buildKey` | String | yes | The unique key identifying the current build phase
+| `buildName` | String | yes | The build phase's name shown on BitBucket
+| `buildDescription` | String | yes | The build phase's description shown on BitBucket
 
 ## Contributions
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <version>1.580.1</version>
+    <version>1.609.1</version>
     <relativePath />
   </parent>
 
@@ -20,6 +20,7 @@
     <maven-hpi-plugin.version>1.112</maven-hpi-plugin.version>
     <maven-deploy-plugin.version>2.6</maven-deploy-plugin.version>
     <wagon-http.version>2.10</wagon-http.version>
+    <workflow.version>1.11</workflow.version>
   </properties>
 
   <name>Bitbucket Build Status Notifier Plugin</name>
@@ -83,6 +84,41 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mercurial</artifactId>
       <version>1.54</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>${workflow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${workflow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>${workflow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-aggregator</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-aggregator</artifactId>
+      <classifier>tests</classifier>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <classifier>tests</classifier>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
@@ -1,0 +1,262 @@
+package org.jenkinsci.plugins.bitbucket;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import hudson.model.*;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.mercurial.MercurialSCM;
+import hudson.scm.SCM;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.util.LogTaskListener;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.eclipse.jgit.transport.URIish;
+
+import org.jenkinsci.plugins.bitbucket.api.BitbucketApi;
+import org.jenkinsci.plugins.bitbucket.api.BitbucketApiService;
+import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatus;
+import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatusResource;
+import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatusSerializer;
+import org.jenkinsci.plugins.bitbucket.scm.GitScmAdapter;
+import org.jenkinsci.plugins.bitbucket.scm.MercurialScmAdapter;
+import org.jenkinsci.plugins.bitbucket.scm.MultiScmAdapter;
+import org.jenkinsci.plugins.bitbucket.scm.ScmAdapter;
+import org.jenkinsci.plugins.bitbucket.validator.BitbucketHostValidator;
+import org.jenkinsci.plugins.multiplescms.MultiSCM;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.scribe.model.*;
+
+class BitbucketBuildStatusHelper {
+    private static final Logger logger = Logger.getLogger(BitbucketBuildStatusHelper.class.getName());
+    private static final BitbucketHostValidator hostValidator = new BitbucketHostValidator();
+
+    private static List<BitbucketBuildStatusResource> createBuildStatusResources(final SCM scm,
+                                                                                 final Run<?, ?> build) throws Exception {
+        List<BitbucketBuildStatusResource> buildStatusResources = new ArrayList<BitbucketBuildStatusResource>();
+
+        if (scm == null) {
+            throw new Exception("Bitbucket build notifier only works with SCM");
+        }
+
+        ScmAdapter scmAdapter;
+        if (scm instanceof GitSCM) {
+            scmAdapter = new GitScmAdapter((GitSCM) scm, build);
+        } else if (scm instanceof MercurialSCM) {
+            scmAdapter = new MercurialScmAdapter((MercurialSCM) scm);
+        } else if (scm instanceof MultiSCM) {
+            scmAdapter = new MultiScmAdapter((MultiSCM)scm, build);
+        } else {
+            throw new Exception("Bitbucket build notifier requires a git repo or a mercurial repo as SCM");
+        }
+
+        Map<String, URIish> commitRepoMap = scmAdapter.getCommitRepoMap();
+        for (Map.Entry<String, URIish> commitRepoPair : commitRepoMap.entrySet()) {
+
+            // if repo is not hosted in bitbucket.org then log it and remove repo from being notified
+            URIish repoUri = commitRepoPair.getValue();
+            if (!hostValidator.isValid(repoUri.getHost())) {
+                logger.log(Level.INFO, hostValidator.renderError());
+                continue;
+            }
+
+            // expand parameters on repo url
+            String repoUrl = build.getEnvironment(new LogTaskListener(logger, Level.INFO)).expand(repoUri.getPath());
+
+            // extract bitbucket user name and repository name from repo URI
+            String repoName = repoUrl.substring(
+                    repoUrl.lastIndexOf("/") + 1,
+                    repoUrl.contains(".git") ? repoUrl.indexOf(".git") : repoUrl.length()
+            );
+
+            if (repoName.isEmpty()) {
+                logger.log(Level.INFO, "Bitbucket build notifier could not extract the repository name from the repository URL");
+                continue;
+            }
+
+            String userName = repoUrl.substring(0, repoUrl.indexOf("/" + repoName));
+            if (userName.contains("/")) {
+                userName = userName.substring(userName.indexOf("/") + 1, userName.length());
+            }
+            if (userName.isEmpty()) {
+                logger.log(Level.INFO, "Bitbucket build notifier could not extract the user name from the repository URL");
+                continue;
+            }
+
+            String commitId = commitRepoPair.getKey();
+            if (commitId == null) {
+                logger.log(Level.INFO, "Commit ID could not be found!");
+                continue;
+            }
+
+            buildStatusResources.add(new BitbucketBuildStatusResource(userName, repoName, commitId));
+        }
+
+        return buildStatusResources;
+    }
+
+    public static List<BitbucketBuildStatusResource> createBuildStatusResources(final Run<?, ?> build) throws Exception {
+        Job<?, ?> project = build.getParent();
+        List<BitbucketBuildStatusResource> buildStatusResources = new ArrayList<BitbucketBuildStatusResource>();
+
+        if(project instanceof WorkflowJob) {
+            Collection<? extends SCM> scms = ((WorkflowJob)project).getSCMs();
+
+            for (SCM scm : scms) {
+                buildStatusResources.addAll(createBuildStatusResources(scm, build));
+            }
+        }
+        else if(project instanceof AbstractProject) {
+            SCM scm = ((AbstractProject)project).getScm();
+            buildStatusResources = createBuildStatusResources(scm, build);
+        }
+
+        return buildStatusResources;
+    }
+
+    public static String defaultBitbucketBuildKeyFromBuild(Run<?, ?> build) {
+        Job<?, ?> project = build.getParent();
+        return DigestUtils.md5Hex(project.getFullDisplayName() + "#" + build.getNumber());
+    }
+
+    public static String defaultBitbucketBuildNameFromBuild(Run<?, ?> build) {
+        Job<?, ?> project = build.getParent();
+        return project.getFullDisplayName() + " #" + build.getNumber();
+    }
+
+    public static String defaultBitbucketBuildDescriptionFromBuild(Run<?, ?> build) {
+        AbstractTestResultAction testResult = build.getAction(AbstractTestResultAction.class);
+        String description = "";
+        if (testResult != null) {
+            int passedCount = testResult.getTotalCount() - testResult.getFailCount();
+            description = passedCount + " of " + testResult.getTotalCount() + " tests passed";
+        }
+        return description;
+    }
+
+    public static String builUrlFromBuild(Run<?, ?> build) {
+        Job<?, ?> project = build.getParent();
+        return project.getAbsoluteUrl() + build.getNumber() + '/';
+    }
+
+    private static BitbucketBuildStatus createBitbucketBuildStatusFromBuild(Run<?, ?> build) throws Exception {
+        String buildState = guessBitbucketBuildState(build.getResult());
+        // bitbucket requires the key to be shorter than 40 chars
+        String buildKey = defaultBitbucketBuildKeyFromBuild(build);
+        String buildUrl = builUrlFromBuild(build);
+        String buildName = defaultBitbucketBuildNameFromBuild(build);
+        String description = defaultBitbucketBuildDescriptionFromBuild(build);
+
+        return new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName, description);
+    }
+
+    private static String guessBitbucketBuildState(final Result result) {
+
+        String state;
+
+        // possible statuses SUCCESS, UNSTABLE, FAILURE, NOT_BUILT, ABORTED
+        if (result == null) {
+            state = BitbucketBuildStatus.INPROGRESS;
+        } else if (Result.SUCCESS == result) {
+            state = BitbucketBuildStatus.SUCCESSFUL;
+        } else if (Result.UNSTABLE == result || Result.FAILURE == result || Result.ABORTED == result) {
+            state = BitbucketBuildStatus.FAILED;
+        } else {
+            // return empty status for every other result (NOT_BUILT, ABORTED)
+            state = null;
+        }
+
+        return state;
+    }
+
+    public static void notifyBuildStatus(final String credentialsId, final Run<?, ?> build,
+                                         final TaskListener listener) throws Exception {
+        notifyBuildStatus(credentialsId, build, listener, createBitbucketBuildStatusFromBuild(build));
+    }
+
+    public static void notifyBuildStatus(final String credentialsId, final Run<?, ?> build,
+                                         final TaskListener listener, BitbucketBuildStatus buildStatus) throws Exception {
+
+        List<BitbucketBuildStatusResource> buildStatusResources = createBuildStatusResources(build);
+
+        Run<?, ?> prevBuild = build.getPreviousBuild();
+        List<BitbucketBuildStatusResource> prevBuildStatusResources = new ArrayList<BitbucketBuildStatusResource>();
+        if (prevBuild != null && prevBuild.getResult() != null && prevBuild.getResult() == Result.ABORTED) {
+            prevBuildStatusResources = createBuildStatusResources(prevBuild);
+        }
+
+        for (BitbucketBuildStatusResource buildStatusResource : buildStatusResources) {
+
+            // if previous build was manually aborted by the user and revision is the same than the current one
+            // then update the bitbucket build status resource with current status and current build number
+            for (BitbucketBuildStatusResource prevBuildStatusResource : prevBuildStatusResources) {
+                if (prevBuildStatusResource.getCommitId().equals(buildStatusResource.getCommitId())) {
+                    BitbucketBuildStatus prevBuildStatus = createBitbucketBuildStatusFromBuild(prevBuild);
+                    buildStatus.setKey(prevBuildStatus.getKey());
+                    break;
+                }
+            }
+
+            sendBuildStatusNotification(credentialsId, build, buildStatusResource, buildStatus, listener);
+        }
+    }
+
+    public static void sendBuildStatusNotification(final String credentialsId,
+                                                   final Run<?, ?> build,
+                                                   final BitbucketBuildStatusResource buildStatusResource,
+                                                   final BitbucketBuildStatus buildStatus,
+                                                   final TaskListener listener) throws Exception {
+        UsernamePasswordCredentials credentials = getCredentials(credentialsId, build.getParent());
+
+        if (credentials == null) {
+            throw new Exception("Credentials could not be found!");
+        }
+
+        OAuthConfig config = new OAuthConfig(credentials.getUsername(), credentials.getPassword().getPlainText());
+        BitbucketApiService apiService = (BitbucketApiService) new BitbucketApi().createService(config);
+
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(BitbucketBuildStatus.class, new BitbucketBuildStatusSerializer());
+        gsonBuilder.setPrettyPrinting();
+        Gson gson = gsonBuilder.create();
+
+        OAuthRequest request = new OAuthRequest(Verb.POST, buildStatusResource.generateUrl(Verb.POST));
+        request.addHeader("Content-type", "application/json");
+        request.addPayload(gson.toJson(buildStatus));
+
+        Token token = apiService.getAccessToken(OAuthConstants.EMPTY_TOKEN, null);
+        apiService.signRequest(token, request);
+
+        Response response = request.send();
+
+        logger.info("This request was sent: " + request.getBodyContents());
+        logger.info("This response was received: " + response.getBody());
+        listener.getLogger().println("Sending build status " + buildStatus.getState() +
+                " for commit " + buildStatusResource.getCommitId() + " to BitBucket is done!");
+    }
+
+    public static StandardUsernamePasswordCredentials getCredentials(String credentialsId, Job<?,?> owner) {
+        if (credentialsId != null) {
+            for (StandardUsernamePasswordCredentials c : CredentialsProvider.lookupCredentials(
+                    StandardUsernamePasswordCredentials.class, owner, null,
+                    URIRequirementBuilder.fromUri(BitbucketApi.OAUTH_ENDPOINT).build())) {
+                if (c.getId().equals(credentialsId)) {
+                    return c;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
@@ -180,12 +180,12 @@ class BitbucketBuildStatusHelper {
         return state;
     }
 
-    public static void notifyBuildStatus(final String credentialsId, final Run<?, ?> build,
+    public static void notifyBuildStatus(UsernamePasswordCredentials credentials, final Run<?, ?> build,
                                          final TaskListener listener) throws Exception {
-        notifyBuildStatus(credentialsId, build, listener, createBitbucketBuildStatusFromBuild(build));
+        notifyBuildStatus(credentials, build, listener, createBitbucketBuildStatusFromBuild(build));
     }
 
-    public static void notifyBuildStatus(final String credentialsId, final Run<?, ?> build,
+    public static void notifyBuildStatus(UsernamePasswordCredentials credentials, final Run<?, ?> build,
                                          final TaskListener listener, BitbucketBuildStatus buildStatus) throws Exception {
 
         List<BitbucketBuildStatusResource> buildStatusResources = createBuildStatusResources(build);
@@ -208,17 +208,15 @@ class BitbucketBuildStatusHelper {
                 }
             }
 
-            sendBuildStatusNotification(credentialsId, build, buildStatusResource, buildStatus, listener);
+            sendBuildStatusNotification(credentials, build, buildStatusResource, buildStatus, listener);
         }
     }
 
-    public static void sendBuildStatusNotification(final String credentialsId,
+    public static void sendBuildStatusNotification(final UsernamePasswordCredentials credentials,
                                                    final Run<?, ?> build,
                                                    final BitbucketBuildStatusResource buildStatusResource,
                                                    final BitbucketBuildStatus buildStatus,
                                                    final TaskListener listener) throws Exception {
-        UsernamePasswordCredentials credentials = getCredentials(credentialsId, build.getParent());
-
         if (credentials == null) {
             throw new Exception("Credentials could not be found!");
         }

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -6,8 +6,6 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -15,37 +13,19 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Item;
 import hudson.model.Job;
-import hudson.model.Result;
-import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.util.BuildData;
-import hudson.plugins.mercurial.MercurialSCM;
-import hudson.scm.SCM;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
-import hudson.tasks.test.AbstractTestResultAction;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import hudson.util.LogTaskListener;
-import java.util.Iterator;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.eclipse.jgit.transport.RemoteConfig;
-import org.eclipse.jgit.transport.URIish;
-import org.jenkinsci.plugins.bitbucket.api.*;
-import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatus;
-import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatusResource;
-import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatusSerializer;
-import org.jenkinsci.plugins.bitbucket.validator.BitbucketHostValidator;
-import org.jenkinsci.plugins.multiplescms.MultiSCM;
+import org.jenkinsci.plugins.bitbucket.api.BitbucketApi;
+import org.jenkinsci.plugins.bitbucket.api.BitbucketApiService;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -55,7 +35,6 @@ import org.scribe.model.*;
 public class BitbucketBuildStatusNotifier extends Notifier {
 
     private static final Logger logger = Logger.getLogger(BitbucketBuildStatusNotifier.class.getName());
-    private static final BitbucketHostValidator hostValidator = new BitbucketHostValidator();
 
     private boolean notifyStart;
     private boolean notifyFinish;
@@ -91,7 +70,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         logger.info("Bitbucket notify on start");
 
         try {
-            this.notifyBuildStatus(build, listener);
+            BitbucketBuildStatusHelper.notifyBuildStatus(getCredentialsId(), build, listener);
         } catch (Exception e) {
             logger.log(Level.INFO, "Bitbucket notify on start failed: " + e.getMessage(), e);
             listener.getLogger().println("Bitbucket notify on start failed: " + e.getMessage());
@@ -112,7 +91,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         logger.info("Bitbucket notify on finish");
 
         try {
-            this.notifyBuildStatus(build, listener);
+            BitbucketBuildStatusHelper.notifyBuildStatus(getCredentialsId(), build, listener);
         } catch (Exception e) {
             logger.log(Level.INFO, "Bitbucket notify on finish failed: " + e.getMessage(), e);
             listener.getLogger().println("Bitbucket notify on finish failed: " + e.getMessage());
@@ -122,18 +101,6 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         logger.info("Bitbucket notify on finish succeeded");
 
         return true;
-    }
-
-    public static StandardUsernamePasswordCredentials getCredentials(String credentialsId, Job<?,?> owner) {
-        if (credentialsId != null) {
-            for (StandardUsernamePasswordCredentials c : CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, owner, null, URIRequirementBuilder.fromUri(BitbucketApi.OAUTH_ENDPOINT).build())) {
-                if (c.getId().equals(credentialsId)) {
-                    return c;
-                }
-            }
-        }
-
-        return null;
     }
 
     @Override
@@ -151,243 +118,6 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         //This is here to ensure that the reported build status is actually correct. If we were to return false here,
         //other build plugins could still modify the build result, making the sent out HipChat notification incorrect.
         return true;
-    }
-
-    private String guessBitbucketBuildState(final Result result) {
-
-        String state;
-
-        // possible statuses SUCCESS, UNSTABLE, FAILURE, NOT_BUILT, ABORTED
-        if (result == null) {
-            state = BitbucketBuildStatus.INPROGRESS;
-        } else if (Result.SUCCESS == result) {
-            state = BitbucketBuildStatus.SUCCESSFUL;
-        } else if (Result.UNSTABLE == result || Result.FAILURE == result || Result.ABORTED == result) {
-            state = BitbucketBuildStatus.FAILED;
-        } else {
-            // return empty status for every other result (NOT_BUILT, ABORTED)
-            state = null;
-        }
-
-        return state;
-    }
-
-    private List<BitbucketBuildStatusResource> createBuildStatusResources(final AbstractBuild build) throws Exception {
-        SCM scm = build.getProject().getScm();
-        if (scm == null) {
-            throw new Exception("Bitbucket build notifier only works with SCM");
-        }
-
-        ScmAdapter scmAdapter;
-        if (scm instanceof GitSCM) {
-            scmAdapter = new GitScmAdapter((GitSCM) scm, build);
-        } else if (scm instanceof MercurialSCM) {
-            scmAdapter = new MercurialScmAdapter((MercurialSCM) scm);
-        } else if (scm instanceof MultiSCM){
-            scmAdapter = new MultiScmAdapter(build);
-        } else {
-            throw new Exception("Bitbucket build notifier requires a git repo or a mercurial repo as SCM");
-        }
-
-        Map<String, URIish> commitRepoMap = scmAdapter.getCommitRepoMap();
-        List<BitbucketBuildStatusResource> buildStatusResources = new ArrayList<BitbucketBuildStatusResource>();
-        for (Map.Entry<String, URIish> commitRepoPair : commitRepoMap.entrySet()) {
-
-            // if repo is not hosted in bitbucket.org then log it and remove repo from being notified
-            URIish repoUri = commitRepoPair.getValue();
-            if (!hostValidator.isValid(repoUri.getHost())) {
-                logger.log(Level.INFO, hostValidator.renderError());
-                continue;
-            }
-
-            // expand parameters on repo url
-            String repoUrl = build.getEnvironment(new LogTaskListener(logger, Level.INFO)).expand(repoUri.getPath());
-
-            // extract bitbucket user name and repository name from repo URI
-            String repoName = repoUrl.substring(
-                    repoUrl.lastIndexOf("/") + 1,
-                    repoUrl.indexOf(".git") > -1 ? repoUrl.indexOf(".git") : repoUrl.length()
-            );
-
-            if (repoName.isEmpty()) {
-                logger.log(Level.INFO, "Bitbucket build notifier could not extract the repository name from the repository URL");
-                continue;
-            }
-
-            String userName = repoUrl.substring(0, repoUrl.indexOf("/" + repoName));
-            if (userName.indexOf("/") != -1) {
-                userName = userName.substring(userName.indexOf("/") + 1, userName.length());
-            }
-            if (userName.isEmpty()) {
-                logger.log(Level.INFO, "Bitbucket build notifier could not extract the user name from the repository URL");
-                continue;
-            }
-
-            String commitId = commitRepoPair.getKey();
-            if (commitId == null) {
-                logger.log(Level.INFO, "Commit ID could not be found!");
-                continue;
-            }
-
-            buildStatusResources.add(new BitbucketBuildStatusResource(userName, repoName, commitId));
-        }
-
-        return buildStatusResources;
-    }
-
-    private void notifyBuildStatus(final AbstractBuild build, final BuildListener listener) throws Exception {
-
-        UsernamePasswordCredentials credentials = BitbucketBuildStatusNotifier.getCredentials(this.getCredentialsId(), build.getProject());
-        List<BitbucketBuildStatusResource> buildStatusResources = this.createBuildStatusResources(build);
-
-        AbstractBuild prevBuild = build.getPreviousBuild();
-        List<BitbucketBuildStatusResource> prevBuildStatusResources = new ArrayList<BitbucketBuildStatusResource>();
-        if (prevBuild != null && prevBuild.getResult() != null && prevBuild.getResult() == Result.ABORTED) {
-            prevBuildStatusResources = this.createBuildStatusResources(prevBuild);
-        }
-
-        for (Iterator<BitbucketBuildStatusResource> i = buildStatusResources.iterator(); i.hasNext(); ) {
-
-            BitbucketBuildStatusResource buildStatusResource = i.next();
-            BitbucketBuildStatus buildStatus = this.createBitbucketBuildStatusFromBuild(build);
-
-            // if previous build was manually aborted by the user and revision is the same than the current one
-            // then update the bitbucket build status resource with current status and current build number
-            for (Iterator<BitbucketBuildStatusResource> j = prevBuildStatusResources.iterator(); j.hasNext(); ) {
-                BitbucketBuildStatusResource prevBuildStatusResource = j.next();
-                if (prevBuildStatusResource.getCommitId().equals(buildStatusResource.getCommitId())) {
-                    BitbucketBuildStatus prevBuildStatus = this.createBitbucketBuildStatusFromBuild(prevBuild);
-                    buildStatus.setKey(prevBuildStatus.getKey());
-                    break;
-                }
-            }
-
-            if (credentials == null) {
-                Job job = null;
-                credentials = BitbucketBuildStatusNotifier.getCredentials(this.getDescriptor().getGlobalCredentialsId(), job);
-            }
-            if (credentials == null) {
-                throw new Exception("Credentials could not be found!");
-            }
-
-            OAuthConfig config = new OAuthConfig(credentials.getUsername(), credentials.getPassword().getPlainText());
-            BitbucketApiService apiService = (BitbucketApiService) new BitbucketApi().createService(config);
-
-            GsonBuilder gsonBuilder = new GsonBuilder();
-            gsonBuilder.registerTypeAdapter(BitbucketBuildStatus.class, new BitbucketBuildStatusSerializer());
-            gsonBuilder.setPrettyPrinting();
-            Gson gson = gsonBuilder.create();
-
-            OAuthRequest request = new OAuthRequest(Verb.POST, buildStatusResource.generateUrl(Verb.POST));
-            request.addHeader("Content-type", "application/json");
-            request.addPayload(gson.toJson(buildStatus));
-
-            Verifier verifier = null;
-            Token token = apiService.getAccessToken(OAuthConstants.EMPTY_TOKEN, verifier);
-            apiService.signRequest(token, request);
-
-            Response response = request.send();
-
-            logger.info("This request was sent: " + request.getBodyContents());
-            logger.info("This response was received: " + response.getBody());
-            listener.getLogger().println("Sending build status " + buildStatus.getState() + " for commit " + buildStatusResource.getCommitId() + " to BitBucket is done!");
-        }
-    }
-
-    private BitbucketBuildStatus createBitbucketBuildStatusFromBuild(AbstractBuild build) throws Exception {
-
-        String buildState = this.guessBitbucketBuildState(build.getResult());
-        // bitbucket requires the key to be shorter than 40 chars
-        String buildKey = DigestUtils.md5Hex(build.getProject().getFullDisplayName() + "#" + build.getNumber());
-        String buildUrl = build.getProject().getAbsoluteUrl() + build.getNumber() + '/';
-        String buildName = build.getProject().getFullDisplayName() + " #" + build.getNumber();
-        AbstractTestResultAction testResult = build.getAction(AbstractTestResultAction.class);
-        String description = "";
-        if (testResult != null) {
-            int passedCount = testResult.getTotalCount() - testResult.getFailCount();
-            description = passedCount + " of " + testResult.getTotalCount() + " tests passed";
-        }
-
-        return new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName, description);
-    }
-
-    private interface ScmAdapter {
-        Map getCommitRepoMap() throws Exception;
-    }
-
-    private class GitScmAdapter implements ScmAdapter {
-
-        private final GitSCM gitScm;
-        private final AbstractBuild build;
-
-        public GitScmAdapter(GitSCM scm, AbstractBuild build) {
-            this.gitScm = scm;
-            this.build = build;
-        }
-
-        public Map getCommitRepoMap() throws Exception {
-            List<RemoteConfig> repoList = this.gitScm.getRepositories();
-            if (repoList.size() != 1) {
-                throw new Exception("None or multiple repos");
-            }
-
-            HashMap<String, URIish> commitRepoMap = new HashMap();
-            BuildData buildData = build.getAction(BuildData.class);
-            if (buildData == null || buildData.getLastBuiltRevision() == null) {
-                logger.warning("Build data could not be found");
-            } else {
-                commitRepoMap.put(buildData.getLastBuiltRevision().getSha1String(), repoList.get(0).getURIs().get(0));
-            }
-
-            return commitRepoMap;
-        }
-    }
-
-    private class MercurialScmAdapter implements ScmAdapter {
-
-        private final MercurialSCM hgSCM;
-
-        public MercurialScmAdapter(MercurialSCM scm) {
-            this.hgSCM = scm;
-        }
-
-        public Map getCommitRepoMap() throws Exception {
-            String source = this.hgSCM.getSource();
-            if (source == null || source.isEmpty()) {
-                throw new Exception("None or multiple repos");
-            }
-
-            HashMap<String, URIish> commitRepoMap = new HashMap();
-            commitRepoMap.put(this.hgSCM.getRevision(), new URIish(this.hgSCM.getSource()));
-
-            return commitRepoMap;
-        }
-    }
-
-    private class MultiScmAdapter implements ScmAdapter {
-
-        private final AbstractBuild build;
-
-        public MultiScmAdapter(AbstractBuild build) {
-            this.build = build;
-        }
-
-        public Map getCommitRepoMap() throws Exception {
-            MultiSCM multiSCM = (MultiSCM) this.build.getProject().getScm();
-            List<SCM> scms = multiSCM.getConfiguredSCMs();
-
-            HashMap<String, URIish> commitRepoMap = new HashMap();
-            for (Iterator<SCM> i = scms.iterator(); i.hasNext(); ) {
-                SCM scm = i.next();
-                if (scm instanceof GitSCM) {
-                    commitRepoMap.putAll(new GitScmAdapter((GitSCM) scm, this.build).getCommitRepoMap());
-                } else if (scm instanceof MercurialSCM) {
-                    commitRepoMap.putAll(new MercurialScmAdapter((MercurialSCM) scm).getCommitRepoMap());
-                }
-            }
-
-            return commitRepoMap;
-        }
     }
 
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
@@ -448,7 +178,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
                 }
             }
 
-            UsernamePasswordCredentials credentials = BitbucketBuildStatusNotifier.getCredentials(credentialsId, owner);
+            UsernamePasswordCredentials credentials = BitbucketBuildStatusHelper.getCredentials(credentialsId, owner);
 
             return this.checkCredentials(credentials);
         }
@@ -468,7 +198,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
             }
 
             Job owner = null;
-            UsernamePasswordCredentials credentials = BitbucketBuildStatusNotifier.getCredentials(globalCredentialsId, owner);
+            UsernamePasswordCredentials credentials = BitbucketBuildStatusHelper.getCredentials(globalCredentialsId, owner);
 
             return this.checkCredentials(credentials);
         }

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
@@ -1,0 +1,419 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Marco Marche (aka trik).
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.bitbucket;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.XmlFile;
+import hudson.model.*;
+
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.util.BuildData;
+import hudson.plugins.mercurial.MercurialSCM;
+import hudson.scm.SCM;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.LogTaskListener;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.bitbucket.api.BitbucketApi;
+import org.jenkinsci.plugins.bitbucket.api.BitbucketApiService;
+import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatus;
+import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatusResource;
+import org.jenkinsci.plugins.bitbucket.model.BitbucketBuildStatusSerializer;
+import org.jenkinsci.plugins.bitbucket.validator.BitbucketHostValidator;
+import org.jenkinsci.plugins.multiplescms.MultiSCM;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.steps.*;
+
+import org.kohsuke.stapler.*;
+import org.scribe.model.*;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
+
+    private static final Logger logger = Logger.getLogger(BitbucketBuildStatusNotifierStep.class.getName());
+    private static final BitbucketHostValidator hostValidator = new BitbucketHostValidator();
+
+    private String credentialsId;
+    public String getCredentialsId() {
+        if (credentialsId == null) {
+            return getDescriptor().getGlobalCredentialsId();
+        }
+        return this.credentialsId;
+    }
+
+    @DataBoundSetter public void setCredentialsId(String credentialsId) {
+        this.credentialsId = credentialsId;
+    }
+
+    private String buildStatus;
+    public String getBuildStatus() { return this.buildStatus; }
+
+    @DataBoundConstructor
+    public BitbucketBuildStatusNotifierStep(final String buildStatus) {
+        this.credentialsId = credentialsId;
+        this.buildStatus = buildStatus;
+    }
+
+    private List<BitbucketBuildStatusResource> createBuildStatusResources(final Run<?, ?> build) throws Exception {
+        WorkflowJob project = (WorkflowJob)build.getParent();
+        Collection<? extends SCM> scms = project.getSCMs();
+        List<BitbucketBuildStatusResource> buildStatusResources = new ArrayList<BitbucketBuildStatusResource>();
+
+        for(SCM scm: scms) {
+            if (scm == null) {
+                throw new Exception("Bitbucket build notifier only works with SCM");
+            }
+
+            BitbucketBuildStatusNotifierStep.ScmAdapter scmAdapter;
+            if (scm instanceof GitSCM) {
+                scmAdapter = new BitbucketBuildStatusNotifierStep.GitScmAdapter((GitSCM) scm, build);
+            } else if (scm instanceof MercurialSCM) {
+                scmAdapter = new BitbucketBuildStatusNotifierStep.MercurialScmAdapter((MercurialSCM) scm);
+            } else if (scm instanceof MultiSCM) {
+                scmAdapter = new BitbucketBuildStatusNotifierStep.MultiScmAdapter(build);
+            } else {
+                throw new Exception("Bitbucket build notifier requires a git repo or a mercurial repo as SCM");
+            }
+
+            Map<String, URIish> commitRepoMap = scmAdapter.getCommitRepoMap();
+            for (Map.Entry<String, URIish> commitRepoPair : commitRepoMap.entrySet()) {
+
+                // if repo is not hosted in bitbucket.org then log it and remove repo from being notified
+                URIish repoUri = commitRepoPair.getValue();
+                if (!hostValidator.isValid(repoUri.getHost())) {
+                    logger.log(Level.INFO, hostValidator.renderError());
+                    continue;
+                }
+
+                // expand parameters on repo url
+                String repoUrl = build.getEnvironment(new LogTaskListener(logger, Level.INFO)).expand(repoUri.getPath());
+
+                // extract bitbucket user name and repository name from repo URI
+                String repoName = repoUrl.substring(
+                        repoUrl.lastIndexOf("/") + 1,
+                        repoUrl.indexOf(".git") > -1 ? repoUrl.indexOf(".git") : repoUrl.length()
+                );
+
+                if (repoName.isEmpty()) {
+                    logger.log(Level.INFO, "Bitbucket build notifier could not extract the repository name from the repository URL");
+                    continue;
+                }
+
+                String userName = repoUrl.substring(0, repoUrl.indexOf("/" + repoName));
+                if (userName.indexOf("/") != -1) {
+                    userName = userName.substring(userName.indexOf("/") + 1, userName.length());
+                }
+                if (userName.isEmpty()) {
+                    logger.log(Level.INFO, "Bitbucket build notifier could not extract the user name from the repository URL");
+                    continue;
+                }
+
+                String commitId = commitRepoPair.getKey();
+                if (commitId == null) {
+                    logger.log(Level.INFO, "Commit ID could not be found!");
+                    continue;
+                }
+
+                buildStatusResources.add(new BitbucketBuildStatusResource(userName, repoName, commitId));
+            }
+        }
+
+        return buildStatusResources;
+    }
+
+    private void notifyBuildStatus(final Run<?, ?> build, final TaskListener listener,
+                                   final StepContext context) throws Exception {
+
+        listener.getLogger().println(getDescriptor().getId().replace("Step", ""));
+        WorkflowJob project = (WorkflowJob)build.getParent();
+        UsernamePasswordCredentials credentials = BitbucketBuildStatusNotifierStep.getCredentials(getCredentialsId(), project);
+        List<BitbucketBuildStatusResource> buildStatusResources = this.createBuildStatusResources(build);
+
+        Run<?, ?> prevBuild = build.getPreviousBuild();
+        List<BitbucketBuildStatusResource> prevBuildStatusResources = new ArrayList<BitbucketBuildStatusResource>();
+        if (prevBuild != null && prevBuild.getResult() != null && prevBuild.getResult() == Result.ABORTED) {
+            prevBuildStatusResources = this.createBuildStatusResources(prevBuild);
+        }
+
+        for (Iterator<BitbucketBuildStatusResource> i = buildStatusResources.iterator(); i.hasNext(); ) {
+
+            BitbucketBuildStatusResource buildStatusResource = i.next();
+            BitbucketBuildStatus buildStatus = this.createBitbucketBuildStatusFromBuild(build);
+
+            // if previous build was manually aborted by the user and revision is the same than the current one
+            // then update the bitbucket build status resource with current status and current build number
+            for (Iterator<BitbucketBuildStatusResource> j = prevBuildStatusResources.iterator(); j.hasNext(); ) {
+                BitbucketBuildStatusResource prevBuildStatusResource = j.next();
+                if (prevBuildStatusResource.getCommitId().equals(buildStatusResource.getCommitId())) {
+                    BitbucketBuildStatus prevBuildStatus = this.createBitbucketBuildStatusFromBuild(prevBuild);
+                    buildStatus.setKey(prevBuildStatus.getKey());
+                    break;
+                }
+            }
+
+            if (credentials == null) {
+                context.onFailure(new Exception("Credentials could not be found!"));
+            }
+
+            OAuthConfig config = new OAuthConfig(credentials.getUsername(), credentials.getPassword().getPlainText());
+            BitbucketApiService apiService = (BitbucketApiService) new BitbucketApi().createService(config);
+
+            GsonBuilder gsonBuilder = new GsonBuilder();
+            gsonBuilder.registerTypeAdapter(BitbucketBuildStatus.class, new BitbucketBuildStatusSerializer());
+            gsonBuilder.setPrettyPrinting();
+            Gson gson = gsonBuilder.create();
+
+            OAuthRequest request = new OAuthRequest(Verb.POST, buildStatusResource.generateUrl(Verb.POST));
+            request.addHeader("Content-type", "application/json");
+            request.addPayload(gson.toJson(buildStatus));
+
+            Verifier verifier = null;
+            Token token = apiService.getAccessToken(OAuthConstants.EMPTY_TOKEN, verifier);
+            apiService.signRequest(token, request);
+
+            Response response = request.send();
+
+            logger.info("This request was sent: " + request.getBodyContents());
+            logger.info("This response was received: " + response.getBody());
+            listener.getLogger().println("Sending build status " + buildStatus.getState() + " for commit " + buildStatusResource.getCommitId() + " to BitBucket is done!");
+        }
+    }
+
+    private BitbucketBuildStatus createBitbucketBuildStatusFromBuild(Run<?, ?> build) throws Exception {
+        WorkflowJob project = (WorkflowJob)build.getParent();
+        String buildState = this.getBuildStatus();
+        // bitbucket requires the key to be shorter than 40 chars
+        String buildKey = DigestUtils.md5Hex(project.getFullDisplayName() + "#" + build.getNumber());
+        String buildUrl = project.getAbsoluteUrl() + build.getNumber() + '/';
+        String buildName = project.getFullDisplayName() + " #" + build.getNumber();
+        AbstractTestResultAction testResult = build.getAction(AbstractTestResultAction.class);
+        String description = "";
+        if (testResult != null) {
+            int passedCount = testResult.getTotalCount() - testResult.getFailCount();
+            description = passedCount + " of " + testResult.getTotalCount() + " tests passed";
+        }
+
+        return new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName, description);
+    }
+
+    public static StandardUsernamePasswordCredentials getCredentials(String credentialsId, Job<?,?> owner) {
+        if (credentialsId != null) {
+            for (StandardUsernamePasswordCredentials c : CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, owner, null, URIRequirementBuilder.fromUri(BitbucketApi.OAUTH_ENDPOINT).build())) {
+                if (c.getId().equals(credentialsId)) {
+                    return c;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private interface ScmAdapter {
+        Map getCommitRepoMap() throws Exception;
+    }
+
+    private class GitScmAdapter implements BitbucketBuildStatusNotifierStep.ScmAdapter {
+
+        private final GitSCM gitScm;
+        private final Run<?, ?> build;
+
+        public GitScmAdapter(GitSCM scm, Run<?, ?> build) {
+            this.gitScm = scm;
+            this.build = build;
+        }
+
+        public Map getCommitRepoMap() throws Exception {
+            List<RemoteConfig> repoList = this.gitScm.getRepositories();
+            if (repoList.size() != 1) {
+                throw new Exception("None or multiple repos");
+            }
+
+            HashMap<String, URIish> commitRepoMap = new HashMap();
+            BuildData buildData = build.getAction(BuildData.class);
+            if (buildData == null || buildData.getLastBuiltRevision() == null) {
+                logger.warning("Build data could not be found");
+            } else {
+                commitRepoMap.put(buildData.getLastBuiltRevision().getSha1String(), repoList.get(0).getURIs().get(0));
+            }
+
+            return commitRepoMap;
+        }
+    }
+
+    private class MercurialScmAdapter implements BitbucketBuildStatusNotifierStep.ScmAdapter {
+
+        private final MercurialSCM hgSCM;
+
+        public MercurialScmAdapter(MercurialSCM scm) {
+            this.hgSCM = scm;
+        }
+
+        public Map getCommitRepoMap() throws Exception {
+            String source = this.hgSCM.getSource();
+            if (source == null || source.isEmpty()) {
+                throw new Exception("None or multiple repos");
+            }
+
+            HashMap<String, URIish> commitRepoMap = new HashMap();
+            commitRepoMap.put(this.hgSCM.getRevision(), new URIish(this.hgSCM.getSource()));
+
+            return commitRepoMap;
+        }
+    }
+
+    private class MultiScmAdapter implements BitbucketBuildStatusNotifierStep.ScmAdapter {
+
+        private final Run<?, ?> build;
+
+        public MultiScmAdapter(Run<?, ?> build) {
+            this.build = build;
+        }
+
+        public Map getCommitRepoMap() throws Exception {
+            WorkflowJob project = (WorkflowJob)this.build.getParent();
+            HashMap<String, URIish> commitRepoMap = new HashMap();
+            for(SCM s: project.getSCMs()) {
+                MultiSCM multiSCM = (MultiSCM)s;
+                List<SCM> scms = multiSCM.getConfiguredSCMs();
+
+                for (Iterator<SCM> i = scms.iterator(); i.hasNext(); ) {
+                    SCM scm = i.next();
+                    if (scm instanceof GitSCM) {
+                        commitRepoMap.putAll(new BitbucketBuildStatusNotifierStep.GitScmAdapter((GitSCM) scm, this.build).getCommitRepoMap());
+                    } else if (scm instanceof MercurialSCM) {
+                        commitRepoMap.putAll(new BitbucketBuildStatusNotifierStep.MercurialScmAdapter((MercurialSCM) scm).getCommitRepoMap());
+                    }
+                }
+            }
+
+            return commitRepoMap;
+        }
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        private String globalCredentialsId;
+
+        public String getGlobalCredentialsId() {
+            return globalCredentialsId;
+        }
+
+        public void setGlobalCredentialsId(String globalCredentialsId) {
+            this.globalCredentialsId = globalCredentialsId;
+        }
+
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override
+        protected XmlFile getConfigFile() {
+            return new XmlFile(new File(Jenkins.getInstance().getRootDir(), this.getId().replace("Step", "") + ".xml"));
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "bitbucketStatusNotify";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Notify a build status to BitBucket.";
+        }
+    }
+
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+        private static final long serialVersionUID = 1L;
+
+        @StepContextParameter
+        private transient TaskListener listener;
+
+        @StepContextParameter
+        private transient FilePath ws;
+
+        @StepContextParameter
+        private transient Run build;
+
+        @StepContextParameter
+        private transient Launcher launcher;
+
+        @Inject
+        private transient BitbucketBuildStatusNotifierStep step;
+
+        private void readGlobalConfiguration() {
+            XmlFile config = step.getDescriptor().getConfigFile();
+            BitbucketBuildStatusNotifier.DescriptorImpl cfg = new BitbucketBuildStatusNotifier.DescriptorImpl();
+            try {
+                config.unmarshal(cfg);
+                step.getDescriptor().setGlobalCredentialsId(cfg.getGlobalCredentialsId());
+            } catch(IOException e) {
+                logger.warning("Unable to read BitbucketBuildStatusNotifier configuration");
+            }
+        }
+
+        @Override
+        public Void run() throws Exception {
+            this.readGlobalConfiguration();
+
+            this.step.notifyBuildStatus(this.build, this.listener, getContext());
+
+            if(step.getBuildStatus().equals(BitbucketBuildStatus.FAILED)) {
+                throw new Exception("Build failed");
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/scm/GitScmAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/scm/GitScmAdapter.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.bitbucket.scm;
+
+import hudson.model.Run;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.util.BuildData;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+
+public class GitScmAdapter implements ScmAdapter {
+    private static final Logger logger = Logger.getLogger(GitScmAdapter.class.getName());
+
+    private final GitSCM gitScm;
+    private final Run<?, ?> build;
+
+    public GitScmAdapter(GitSCM scm, Run<?, ?> build) {
+        this.gitScm = scm;
+        this.build = build;
+    }
+
+    public Map<String, URIish> getCommitRepoMap() throws Exception {
+        List<RemoteConfig> repoList = this.gitScm.getRepositories();
+        if (repoList.size() != 1) {
+            throw new Exception("None or multiple repos");
+        }
+
+        HashMap<String, URIish> commitRepoMap = new HashMap<String, URIish>();
+        BuildData buildData = build.getAction(BuildData.class);
+        if (buildData == null || buildData.getLastBuiltRevision() == null) {
+            logger.warning("Build data could not be found");
+        } else {
+            commitRepoMap.put(buildData.getLastBuiltRevision().getSha1String(), repoList.get(0).getURIs().get(0));
+        }
+
+        return commitRepoMap;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/scm/MercurialScmAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/scm/MercurialScmAdapter.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.bitbucket.scm;
+
+import hudson.plugins.mercurial.MercurialSCM;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jgit.transport.URIish;
+
+public class MercurialScmAdapter implements ScmAdapter {
+
+    private final MercurialSCM hgSCM;
+
+    public MercurialScmAdapter(MercurialSCM scm) {
+        this.hgSCM = scm;
+    }
+
+    public Map<String, URIish> getCommitRepoMap() throws Exception {
+        String source = this.hgSCM.getSource();
+        if (source == null || source.isEmpty()) {
+            throw new Exception("None or multiple repos");
+        }
+
+        HashMap<String, URIish> commitRepoMap = new HashMap<String, URIish>();
+        commitRepoMap.put(this.hgSCM.getRevision(), new URIish(this.hgSCM.getSource()));
+
+        return commitRepoMap;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/scm/MultiScmAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/scm/MultiScmAdapter.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.bitbucket.scm;
+
+import hudson.model.Run;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.mercurial.MercurialSCM;
+import hudson.scm.SCM;
+
+import org.eclipse.jgit.transport.URIish;
+
+import org.jenkinsci.plugins.multiplescms.MultiSCM;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class MultiScmAdapter implements ScmAdapter {
+
+    private final MultiSCM multiScm;
+    private final Run<?, ?> build;
+
+    public MultiScmAdapter(MultiSCM multiScm, Run<?, ?> build) {
+        this.multiScm = multiScm;
+        this.build = build;
+    }
+
+    public Map getCommitRepoMap() throws Exception {
+        HashMap<String, URIish> commitRepoMap = new HashMap<String, URIish>();
+        List<SCM> scms = multiScm.getConfiguredSCMs();
+
+        for (Iterator<SCM> i = scms.iterator(); i.hasNext(); ) {
+            SCM scm = i.next();
+            if (scm instanceof GitSCM) {
+                commitRepoMap.putAll(new GitScmAdapter((GitSCM) scm, this.build).getCommitRepoMap());
+            } else if (scm instanceof MercurialSCM) {
+                commitRepoMap.putAll(new MercurialScmAdapter((MercurialSCM) scm).getCommitRepoMap());
+            }
+        }
+
+        return commitRepoMap;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/scm/ScmAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/scm/ScmAdapter.java
@@ -1,0 +1,9 @@
+package org.jenkinsci.plugins.bitbucket.scm;
+
+import org.eclipse.jgit.transport.URIish;
+
+import java.util.Map;
+
+public interface ScmAdapter {
+    Map<String, URIish> getCommitRepoMap() throws Exception;
+}


### PR DESCRIPTION
I admit it's not the best implementation ever, anyway it works and i think it could be a good start to work on. It needs some refactoring, the step and the standard notifier share a lot of code that should be exported in separate classes (SCM classes and some kind of helper for the build status creation).

example of usage:

```groovy
try {
     bitbucketStatusNotify(buildStatus: 'INPROGRESS')
     step 'Build'
        aBuildFunction()
     step 'Test'
        myCoolTestFunction()
     bitbucketStatusNotify(buildStatus: 'SUCCESSFUL')
} catch(Exception e) {
     bitbucketStatusNotify(buildStatus: 'FAILED')
}
```

with buildStatus 'FAILED', it raises a new exception, blocking the pipeline flow