### PR TITLE
Distinguish between Bitbucket Cloud / Stash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Bitbucket build status notifier plugin for Jenkins - [![Build Status][jenkins-status]][jenkins-builds]
+# Bitbucket Cloud build status notifier plugin for Jenkins - [![Build Status][jenkins-status]][jenkins-builds]
 
 Every time you trigger a build, you don't have to log in to your build server to see if it passed or failed. Now
 you will be able to know when your build is passing right within the Bitbucket UI.
+
+Note: This plugin aims at the Atlassian-hosted BitBucket Cloud solution, not BitBucket Server (formerly known as Stash).
 
 ## Features
 


### PR DESCRIPTION
Add a note that this plugin doesn't support Bitbucket Server ("Stash").