### PR TITLE
Update link to plugin wiki page in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <name>Bitbucket Build Status Notifier Plugin</name>
   <description>Integrates Jenkins build status with BitBucket</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+Build+Status+Notifier+Plugin</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+Cloud+Build+Status+Notifier+Plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>


### PR DESCRIPTION
This update the link to the plugin wike page, since it changed and it seems to have some effects, since the plugin information is not available in the wiki page anymore.