### PR TITLE
Fix JENKINS-35083

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -106,7 +106,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         logger.info("Bitbucket notify on start");
 
         try {
-            BitbucketBuildStatusHelper.notifyBuildStatus(this.getCredentials(build), build, listener);
+            BitbucketBuildStatusHelper.notifyBuildStatus(this.getCredentials(build), this.getOverrideLatestBuild(), build, listener);
         } catch (Exception e) {
             listener.getLogger().println("Bitbucket notify on start failed: " + e.getMessage());
             e.printStackTrace(listener.getLogger());
@@ -126,7 +126,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         logger.info("Bitbucket notify on finish");
 
         try {
-            BitbucketBuildStatusHelper.notifyBuildStatus(this.getCredentials(build), build, listener);
+            BitbucketBuildStatusHelper.notifyBuildStatus(this.getCredentials(build), this.getOverrideLatestBuild(), build, listener);
         } catch (Exception e) {
             logger.log(Level.INFO, "Bitbucket notify on finish failed: " + e.getMessage(), e);
             listener.getLogger().println("Bitbucket notify on finish failed: " + e.getMessage());

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -58,14 +58,16 @@ public class BitbucketBuildStatusNotifier extends Notifier {
 
     private boolean notifyStart;
     private boolean notifyFinish;
+    private boolean overrideLatestBuild;
     private String credentialsId;
 
     @DataBoundConstructor
     public BitbucketBuildStatusNotifier(final boolean notifyStart, final boolean notifyFinish,
-                                        final String credentialsId) {
+                                        final boolean overrideLatestBuild, final String credentialsId) {
         super();
         this.notifyStart = notifyStart;
         this.notifyFinish = notifyFinish;
+        this.overrideLatestBuild = overrideLatestBuild;
         this.credentialsId = credentialsId;
     }
 
@@ -75,6 +77,10 @@ public class BitbucketBuildStatusNotifier extends Notifier {
 
     public boolean getNotifyFinish() {
         return this.notifyFinish;
+    }
+
+    public boolean getOverrideLatestBuild() {
+        return this.overrideLatestBuild;
     }
 
     public String getCredentialsId() {

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
@@ -186,7 +186,7 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
             BitbucketBuildStatus buildStatus = new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName,
                     buildDescription);
 
-            BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), build, taskListener, buildStatus);
+            BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), false, build, taskListener, buildStatus);
 
             if(buildState.equals(BitbucketBuildStatus.FAILED)) {
                 throw new Exception(buildDescription);

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/config.jelly
@@ -6,6 +6,9 @@
     <f:entry title="${%Notify build finish}" field="notifyFinish">
         <f:checkbox />
     </f:entry>
+    <f:entry title="${%Only show latest build status}" field="overrideLatestBuild">
+        <f:checkbox />
+    </f:entry>
     <f:advanced>
         <f:entry title="${%Credentials}" field="credentialsId">
             <c:select />


### PR DESCRIPTION
Add configuration option for showing only the latest build status on bitbucket per jenkins job, so the build status is going to be overridden for every build.  