### PR TITLE
made the exception throwing on FAILED status in pipeline jobs configurable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -159,7 +159,9 @@ public class BitbucketBuildStatusNotifier extends Notifier {
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         private String globalCredentialsId;
-        
+
+        private boolean globalErrorWhenFailed;
+
         public DescriptorImpl() {
             load();
         }
@@ -170,6 +172,12 @@ public class BitbucketBuildStatusNotifier extends Notifier {
 
         public void setGlobalCredentialsId(String globalCredentialsId) {
             this.globalCredentialsId = globalCredentialsId;
+        }
+
+        public boolean getGlobalErrorWhenFailed() { return globalErrorWhenFailed; }
+
+        public void setGlobalErrorWhenFailed(boolean globalErrorWhenFailed) {
+            this.globalErrorWhenFailed = globalErrorWhenFailed;
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
@@ -109,12 +109,20 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
 
         private String globalCredentialsId;
 
+        private boolean globalErrorWhenFailed;
+
         public String getGlobalCredentialsId() {
             return globalCredentialsId;
         }
 
         public void setGlobalCredentialsId(String globalCredentialsId) {
             this.globalCredentialsId = globalCredentialsId;
+        }
+
+        public boolean getGlobalErrorWhenFailed() { return globalErrorWhenFailed; }
+
+        public void setGlobalErrorWhenFailed(boolean globalErrorWhenFailed) {
+            this.globalErrorWhenFailed = globalErrorWhenFailed;
         }
 
         public DescriptorImpl() {
@@ -155,6 +163,7 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
             try {
                 config.unmarshal(cfg);
                 step.getDescriptor().setGlobalCredentialsId(cfg.getGlobalCredentialsId());
+                step.getDescriptor().setGlobalErrorWhenFailed(cfg.getGlobalErrorWhenFailed());
             } catch(IOException e) {
                 logger.warning("Unable to read BitbucketBuildStatusNotifier configuration");
             }
@@ -188,7 +197,7 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
 
             BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), false, build, taskListener, buildStatus);
 
-            if(buildState.equals(BitbucketBuildStatus.FAILED)) {
+            if(step.getDescriptor().getGlobalErrorWhenFailed() && buildState.equals(BitbucketBuildStatus.FAILED)) {
                 throw new Exception(buildDescription);
             }
 

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/global.jelly
@@ -4,5 +4,8 @@
         <f:entry title="${%Global Credentials}" field="globalCredentialsId">
             <c:select />
         </f:entry>
+        <f:entry title="${%Throw Exception When Notifying FAILED Status}" field="globalErrorWhenFailed">
+            <f:checkbox default="true" />
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/help-globalErrorWhenFailed.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/help-globalErrorWhenFailed.html
@@ -1,0 +1,3 @@
+<div>
+    <p>If checked, using this plugin to send 'FAILED' build status inside a Pipeline job will cause the plugin to throw an exception, terminating the build.</p>
+</div>


### PR DESCRIPTION
I hope I am not overstepping here, but I find the behavior of throwing an exception whenever sending a FAILED build status to be a mistake. It forces using the plugin to be the very last notifier to be called in a pipeline. Now imagine you have more than one such notifiers, and a couple of them read the build status and throws an exception when FAILED. Only the first will actually fire.

From the new pipeline perspective, the pipeline should either use a `catchError` clause, which allows for post-fail actions without changing the build status, or manually set the `currentBuild.result` argument as desired.

 Following this logic, but still seeing why some people would want the existing behavior, I added a checkbox to the Global Configurations section (made it `true` by default, to reflect the original implementation) which will control this behavior so anyone can choose their own preferred way of doing thing.
