### PR TITLE
Notifying BitBucket of build failure causes an exception to be thrown.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
@@ -188,10 +188,6 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
 
             BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), false, build, taskListener, buildStatus);
 
-            if(buildState.equals(BitbucketBuildStatus.FAILED)) {
-                throw new Exception(buildDescription);
-            }
-
             return null;
         }
     }


### PR DESCRIPTION
Simply adding `bitbucketStatusNotify buildState: 'FAILED'` to a pipeline script causes the build to fail.
In my opinion the bit bucket status notifier should do just that: notify bitbucket of the build status.

This PR simply removes the exception throwing part.
