### PR TITLE
Add optional parameters for the bitbucket repo slug and the commit id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 *.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -100,42 +100,54 @@ If `buildKey` and `buildName` parameters are not provided, a standard name will 
     bitbucketStatusNotify(
       buildState: 'INPROGRESS',
       buildKey: 'build',
-      buildName: 'Build'
+      buildName: 'Build',
+      repoSlug: 'my-awesome-project',
+      commitId: 'a83c709e9d514421ef614ef0a1117366c84c6304'      
     )
     try {
         myBuildFunction()
         bitbucketStatusNotify(
           buildState: 'SUCCESSFUL',
           buildKey: 'build',
-          buildName: 'Build'
+          buildName: 'Build',
+          repoSlug: 'my-awesome-project',
+          commitId: 'a83c709e9d514421ef614ef0a1117366c84c6304'          
         )
     } catch(Exception e) {
         bitbucketStatusNotify(
           buildState: 'FAILED',
           buildKey: 'build',
           buildName: 'Build',
-          buildDescription: 'Something went wrong with build!'
+          buildDescription: 'Something went wrong with build!',
+          repoSlug: 'my-awesome-project',
+          commitId: 'a83c709e9d514421ef614ef0a1117366c84c6304'      
         )
     }
   stage 'Test'
     bitbucketStatusNotify(
       buildState: 'INPROGRESS',
       buildKey: 'test',
-      buildName: 'Test'
+      buildName: 'Test',
+      repoSlug: 'my-awesome-project',
+      commitId: 'a83c709e9d514421ef614ef0a1117366c84c6304'
     )
     try {
         myTestFunction()
         bitbucketStatusNotify(
           buildState: 'SUCCESSFUL',
           buildKey: 'test',
-          buildName: 'Test'
+          buildName: 'Test',
+          repoSlug: 'my-awesome-project',
+          commitId: 'a83c709e9d514421ef614ef0a1117366c84c6304'
         )
     } catch(Exception e) {
         bitbucketStatusNotify(
           buildState: 'FAILED',
           buildKey: 'test',
           buildName: 'Test',
-          buildDescription: 'Something went wrong with tests!'
+          buildDescription: 'Something went wrong with tests!',
+          repoSlug: 'my-awesome-project',
+          commitId: 'a83c709e9d514421ef614ef0a1117366c84c6304'
         )
     }
   ...
@@ -151,6 +163,10 @@ Parameter:
 | `buildKey` | String | yes | The unique key identifying the current build phase
 | `buildName` | String | yes | The build phase's name shown on BitBucket
 | `buildDescription` | String | yes | The build phase's description shown on BitBucket
+| `repoSlug`| String | yes | The slug of the bitbucket repository to send the notification to
+| `commitId` | String | yes | The id of the commit to attach the status notification to 
+
+Note that the `repoSlug` and `commitId` parameters work only when they are both specified.
 
 ## Contributions
 

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
@@ -221,12 +221,12 @@ class BitbucketBuildStatusHelper {
 
     public static void notifyBuildStatus(UsernamePasswordCredentials credentials, boolean overrideLatestBuild,
                                          final Run<?, ?> build, final TaskListener listener) throws Exception {
-        notifyBuildStatus(credentials, overrideLatestBuild, build, listener, createBitbucketBuildStatusFromBuild(build, overrideLatestBuild));
+        notifyBuildStatus(credentials, overrideLatestBuild, build, listener, createBitbucketBuildStatusFromBuild(build, overrideLatestBuild), null, null);
     }
 
     public static void notifyBuildStatus(UsernamePasswordCredentials credentials, boolean overrideLatestBuild,
                                          final Run<?, ?> build, final TaskListener listener,
-                                         BitbucketBuildStatus buildStatus) throws Exception {
+                                         BitbucketBuildStatus buildStatus, String repoSlug, String commitId) throws Exception {
 
         List<BitbucketBuildStatusResource> buildStatusResources = createBuildStatusResources(build);
 
@@ -247,6 +247,10 @@ class BitbucketBuildStatusHelper {
 
                     break;
                 }
+            }
+
+            if(repoSlug != null && commitId != null) {
+                buildStatusResource = new BitbucketBuildStatusResource(buildStatusResource.getOwner(), repoSlug, commitId);
             }
 
             sendBuildStatusNotification(credentials, build, buildStatusResource, buildStatus, listener);

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier.java
@@ -105,6 +105,7 @@ public class BitbucketBuildStatusNotifier extends Notifier {
         }
         logger.info("Bitbucket notify on start");
 
+
         try {
             BitbucketBuildStatusHelper.notifyBuildStatus(this.getCredentials(build), this.getOverrideLatestBuild(), build, listener);
         } catch (Exception e) {

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
@@ -83,6 +83,18 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
     private String buildState;
     public String getBuildState() { return this.buildState; }
 
+    private String repoSlug;
+    public String getRepoSlug() { return this.repoSlug; }
+    @DataBoundSetter public void setRepoSlug(String repoSlug) {
+        this.repoSlug = repoSlug;
+    }
+
+    private String commitId;
+    public String getCommitId() { return this.commitId; }
+    @DataBoundSetter public void setCommitId(String commitId) {
+        this.commitId = commitId;
+    }
+
     @DataBoundConstructor
     public BitbucketBuildStatusNotifierStep(final String buildState) {
         this.credentialsId = credentialsId;
@@ -181,12 +193,17 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
                 buildDescription = BitbucketBuildStatusHelper.defaultBitbucketBuildDescriptionFromBuild(build);
             }
 
+            String commitId = step.getCommitId();
+            String repoSlug = step.getRepoSlug();
+            logger.info("Got commit id " + commitId);
+            logger.info("Got repo slug = " + repoSlug);
+
             String buildUrl = BitbucketBuildStatusHelper.buildUrlFromBuild(build);
 
             BitbucketBuildStatus buildStatus = new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName,
                     buildDescription);
 
-            BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), false, build, taskListener, buildStatus);
+            BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), false, build, taskListener, buildStatus, repoSlug, commitId);
 
             return null;
         }


### PR DESCRIPTION
There are [several](https://issues.jenkins-ci.org/browse/JENKINS-41214) [issues](https://issues.jenkins-ci.org/browse/JENKINS-41602) around about this plugin notifying the wrong repository on multibranch pipelines and/or in scenarios where a shared pipeline library is obtained from SCM before the build starts, as Jenkins seem to be handling the current repository improperly.

By adding optional parameters to explicitly set the repository and the commit id (which should already be available during the pipeline execution, or anyway pretty easy to obtain) to send notifications to, this change should solve these issues, while preserving the original plugin behavior.