### PR TITLE
Only override buildKey when overrideLatestBuild.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusHelper.java
@@ -245,8 +245,8 @@ class BitbucketBuildStatusHelper {
             // if previous build was manually aborted by the user and revision is the same than the current one
             // then update the bitbucket build status resource with current status and current build number
             for (BitbucketBuildStatusResource prevBuildStatusResource : prevBuildStatusResources) {
-                if (prevBuildStatusResource.getCommitId().equals(buildStatusResource.getCommitId())) {
-                    BitbucketBuildStatus prevBuildStatus = createBitbucketBuildStatusFromBuild(prevBuild, overrideLatestBuild);
+                if (prevBuildStatusResource.getCommitId().equals(buildStatusResource.getCommitId()) && overrideLatestBuild) {
+                    BitbucketBuildStatus prevBuildStatus = createBitbucketBuildStatusFromBuild(prevBuild, true);
                     buildStatus.setKey(prevBuildStatus.getKey());
 
                     break;


### PR DESCRIPTION
This pull request makes sure that the buildKey of BitbucketBuildStatusNotifierStep calls, are not incorrectly overriden.

**Current behaviour**
1. Create a pipeline which calls `bitbucketStatusNotify` with a static `buildKey`, e.g. `build`.
2. Fail the pipeline, so Bitbucket gets a failed build.
3. Rerun the pipeline. Bitbucket will show it as a new build, instead of overriding the previous build result.

**Fixed behaviour**
1. Create a pipeline which calls `bitbucketStatusNotify` with a static `buildKey`, e.g. `build`.
2. Fail the pipeline, so Bitbucket gets a failed build.
3. Rerun the pipeline. Bitbucket will correctly replace the previous result, with the latest one.