### PR TITLE
Throw exception if no git repos found

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/scm/GitScmAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/scm/GitScmAdapter.java
@@ -49,8 +49,8 @@ public class GitScmAdapter implements ScmAdapter {
 
     public Map<String, URIish> getCommitRepoMap() throws Exception {
         List<RemoteConfig> repoList = this.gitScm.getRepositories();
-        if (repoList.size() != 1) {
-            throw new Exception("None or multiple repos");
+        if (repoList.size() < 1) {
+            throw new Exception("No repos found");
         }
 
         HashMap<String, URIish> commitRepoMap = new HashMap<String, URIish>();


### PR DESCRIPTION
This plugin throws an exception if there isn't exactly one one git repository. However, during a pull request, there can be more than one remote configs, which means more than one git repository. 

In my case, I'm using the bitbucket-branch-source-plugin, but have disabled the notifications because of the lack of control and customization of the bitbucket status messages. 

In order to resolve this, I'm proposing that we only throw an exception when there are no repositories. I think this works fine since you're only using the first repository in the list anyway.