### PR TITLE
New feature: override buildUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Parameter:
 | `buildKey` | String | yes | The unique key identifying the current build phase
 | `buildName` | String | yes | The build phase's name shown on BitBucket
 | `buildDescription` | String | yes | The build phase's description shown on BitBucket
+| `buildUrl` | String | yes | The url linked to the phase in BitBucket. To link to a Jenkins artifact use `"${BUILD_URL}artifact/example.txt"`
 | `repoSlug`| String | yes | The slug of the bitbucket repository to send the notification to
 | `commitId` | String | yes | The id of the commit to attach the status notification to 
 

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
@@ -77,6 +77,12 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
         this.buildDescription = buildDescription;
     }
 
+    private String buildUrl;
+    public String getBuildUrl() { return this.buildUrl; }
+    @DataBoundSetter public void setBuildUrl(String buildUrl) {
+        this.buildUrl = buildUrl;
+    }
+
     private String buildState;
     public String getBuildState() { return this.buildState; }
 
@@ -194,7 +200,10 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
             logger.info("Got commit id " + commitId);
             logger.info("Got repo slug = " + repoSlug);
 
-            String buildUrl = BitbucketBuildStatusHelper.buildUrlFromBuild(build);
+            String buildUrl = step.getBuildUrl();
+            if (buildUrl == null) {
+                buildUrl = BitbucketBuildStatusHelper.buildUrlFromBuild(build);
+            }
 
             BitbucketBuildStatus buildStatus = new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName,
                     buildDescription);


### PR DESCRIPTION
This allows the user of the plugin to set a different buildUrl.
Bitbucket navigates to this Url when you click the buildName.

The buildUrl will often be an artifact hosted by Jenkins. The user can
concat this themselves from the BUILD_URL environment variable