### PR TITLE
Use Github as source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <name>Bitbucket Build Status Notifier Plugin</name>
   <description>Integrates Jenkins build status with BitBucket</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+Cloud+Build+Status+Notifier+Plugin</url>
+  <url>https://github.com/jenkinsci/bitbucket-build-status-notifier-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
Load documentation from Github instead of the wiki.

Related tickets:
https://issues.jenkins-ci.org/browse/WEBSITE-406
https://issues.jenkins-ci.org/browse/JENKINS-59172

More info:  https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/
