### PR TITLE
Feature/jenkins 35083 adding option to override build for pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Parameter:
 | `buildName` | String | yes | The build phase's name shown on BitBucket
 | `buildDescription` | String | yes | The build phase's description shown on BitBucket
 | `repoSlug`| String | yes | The slug of the bitbucket repository to send the notification to
-| `commitId` | String | yes | The id of the commit to attach the status notification to 
+| `commitId` | String | yes | The id of the commit to attach the status notification to
+| `overrideLatestBuild` | String | yes | If set to `true` will override the last build on Bitbucket (useful for requiring successful builds on pr merge). Defaults to false.
 
 Note that the `repoSlug` and `commitId` parameters work only when they are both specified.
 

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifierStep.java
@@ -92,6 +92,14 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
         this.commitId = commitId;
     }
 
+    private String overrideLatestBuild;
+    public Boolean getOverrideLatestBuildOrDefault() {
+        return Boolean.valueOf(this.overrideLatestBuild);
+    }
+    @DataBoundSetter public void setOverrideLatestBuild(String overrideLatestBuild) {
+        this.overrideLatestBuild = overrideLatestBuild;
+    }
+
     @DataBoundConstructor
     public BitbucketBuildStatusNotifierStep(final String buildState) {
         this.buildState = buildState;
@@ -199,7 +207,7 @@ public class BitbucketBuildStatusNotifierStep extends AbstractStepImpl {
             BitbucketBuildStatus buildStatus = new BitbucketBuildStatus(buildState, buildKey, buildUrl, buildName,
                     buildDescription);
 
-            BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), false, build, taskListener, buildStatus, repoSlug, commitId);
+            BitbucketBuildStatusHelper.notifyBuildStatus(step.getCredentials(build), step.getOverrideLatestBuildOrDefault(), build, taskListener, buildStatus, repoSlug, commitId);
 
             return null;
         }


### PR DESCRIPTION
Adding the option to override latest build also on the declaritve pipeline mode. 

Fixes: https://issues.jenkins.io/browse/JENKINS-35083

This is necessary as bitbucket will require all builds to pass for a merge check.