### PR TITLE
JENKINS-53232 Add possibility to take commit ID from environment variable in case the actual one is incorrect (for example due to "Merge before build"

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/config.jelly
@@ -14,4 +14,7 @@
             <c:select />
         </f:entry>
     </f:advanced>
+    <f:entry title="${%Override commit ID from environment variable}" field="overrideCommitIdVar">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/help-overrideCommitIdVar.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/BitbucketBuildStatusNotifier/help-overrideCommitIdVar.html
@@ -1,0 +1,4 @@
+<div>
+	<p>When using for example "Merge before build", and a merge commit is performed, Bitbucket is notified with the commit ID of the merge commit
+		performed by Jenkins, which is unknown by Bitbucket. Specify here an environment variable containing the correct commit ID.</p>
+</div>


### PR DESCRIPTION
When using the "Merge before build", and a merge commit is performed, the plugin notifies Bitbucket with the commit ID of the merge commit, which is only known to Jenkins, not Bitbucket. This means the commit is not marked as successful build.
With this change you can override the commit ID with one stored in an environment variable.

JENKINS-53232

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [*] Ensure you have provided tests - that demonstrates feature works or fixes the issue

* No tests have been added as plugin does not provide any tests yet.