### PR TITLE
Updated codebase to make it compile with latest versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@ buildPlugin(
   forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 11],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildPlugin(
+  jdkVersions: [11, 17],
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 17],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
-#!groovy
-
-buildPlugin()
-
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 buildPlugin(
-  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
 ])

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ you will be able to know when your build is passing right within the Bitbucket C
 
 Note: This plugin aims at the Atlassian-hosted BitBucket Cloud solution, not BitBucket Server (formerly known as Stash).
 
+## Build plugin
+
+```
+docker run --rm -it \
+    -v maven-repo:/root/.m2 \
+    -v .:/usr/src/mymaven \
+    -w /usr/src/mymaven \
+    maven:latest mvn clean install
+```
+
 ## Features
 
 * Notify to Bitbucket for the following build events:

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-
-    <version>4.46</version>
+    <version>4.53</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <workflow.version>2.80</workflow.version>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
     <jenkins.version>2.387.3</jenkins.version>
-    <java.version>8</java.version>
+    <java.version>11</java.version>
   </properties>
 
   <name>Bitbucket Build Status Notifier Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.53</version>
+    <version>4.80</version>
     <relativePath />
   </parent>
 
@@ -166,38 +166,6 @@
         <groupId>com.cloudbees</groupId>
         <artifactId>maven-license-plugin</artifactId>
         <version>1.17</version>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.7.3.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>9.5</version>
-          </dependency>
-          <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-analysis</artifactId>
-            <version>9.5</version>
-          </dependency>
-          <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-commons</artifactId>
-            <version>9.5</version>
-          </dependency>
-          <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-tree</artifactId>
-            <version>9.5</version>
-          </dependency>
-          <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-util</artifactId>
-            <version>9.5</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.80</version>
+    <version>4.83</version>
     <relativePath />
   </parent>
 
@@ -41,9 +41,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/bitbucket-build-status-notifier-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/bitbucket-build-status-notifier-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/bitbucket-build-status-notifier-plugin</url>
+    <connection>scm:git:https://github.com/jenkinsci/bitbucket-build-status-notifier-plugin.git</connection>
+    <developerConnection>scm:git:https://github.com:jenkinsci/bitbucket-build-status-notifier-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/bitbucket-build-status-notifier-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -135,10 +135,7 @@
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <extensions>true</extensions>
-        <version>3.53</version>
-        <configuration>
-          <minimumJavaVersion>11</minimumJavaVersion>
-        </configuration>
+        <version>3.55</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <version>1.609.1</version>
+
+    <version>4.46</version>
     <relativePath />
   </parent>
 
@@ -15,11 +15,11 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
-    <maven-hpi-plugin.version>1.112</maven-hpi-plugin.version>
-    <maven-deploy-plugin.version>2.6</maven-deploy-plugin.version>
     <wagon-http.version>2.10</wagon-http.version>
-    <workflow.version>1.11</workflow.version>
+    <workflow.version>2.80</workflow.version>
+    <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
+    <jenkins.version>2.387.3</jenkins.version>
+    <java.version>8</java.version>
   </properties>
 
   <name>Bitbucket Build Status Notifier Plugin</name>
@@ -74,78 +74,60 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2244.vd60654536b_96</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mercurial</artifactId>
-      <version>1.54</version>
+      <version>1260.vdfb_723cdcc81</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>${workflow.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps</artifactId>
-      <version>${workflow.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>${workflow.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-aggregator</artifactId>
-      <version>${workflow.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-aggregator</artifactId>
-      <classifier>tests</classifier>
-      <version>${workflow.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-      <classifier>tests</classifier>
-      <version>${workflow.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.2.2</version>
+      <version>2.10.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.scribe</groupId>
       <artifactId>scribe</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.22</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>0.4</version>
     </dependency>
+
   </dependencies>
 
   <build>
@@ -153,7 +135,6 @@
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>${maven-hpi-plugin.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>
@@ -166,22 +147,56 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>${maven-release-plugin.version}</version>
         <configuration>
           <goals>deploy</goals>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-http</artifactId>
             <version>${wagon-http.version}</version>
             <type>jar</type>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>com.cloudbees</groupId>
+        <artifactId>maven-license-plugin</artifactId>
+        <version>1.17</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.7.3.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.5</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-analysis</artifactId>
+            <version>9.5</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>9.5</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <version>9.5</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>9.5</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,10 @@
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <extensions>true</extensions>
+        <version>3.53</version>
+        <configuration>
+          <minimumJavaVersion>11</minimumJavaVersion>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/api/BitbucketApiService.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/api/BitbucketApiService.java
@@ -28,6 +28,7 @@ import org.eclipse.jgit.util.Base64;
 import org.scribe.builder.api.DefaultApi20;
 import org.scribe.model.*;
 import org.scribe.oauth.OAuth20ServiceImpl;
+import java.nio.charset.StandardCharsets;
 
 public class BitbucketApiService extends OAuth20ServiceImpl {
 
@@ -60,8 +61,9 @@ public class BitbucketApiService extends OAuth20ServiceImpl {
 
     private String getHttpBasicAuthHeaderValue() {
         String authStr = config.getApiKey() + ":" + config.getApiSecret();
+        byte[] bin = authStr.getBytes(StandardCharsets.UTF_8);
 
-        return "Basic " + Base64.encodeBytes(authStr.getBytes());
+        return "Basic " + Base64.encodeBytes(bin);
     }
 
     private String getBearerAuthHeaderValue(Token token) {

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/scm/GitScmAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/scm/GitScmAdapter.java
@@ -39,22 +39,20 @@ import org.eclipse.jgit.transport.URIish;
 public class GitScmAdapter implements ScmAdapter {
     private static final Logger logger = Logger.getLogger(GitScmAdapter.class.getName());
 
-    private final GitSCM gitScm;
-    private final Run<?, ?> build;
+    private final BuildData buildData;
+    private final List<RemoteConfig> repoList;
 
     public GitScmAdapter(GitSCM scm, Run<?, ?> build) {
-        this.gitScm = scm;
-        this.build = build;
+        this.repoList = scm.getRepositories();
+        this.buildData = build.getAction(BuildData.class);
     }
 
     public Map<String, URIish> getCommitRepoMap() throws Exception {
-        List<RemoteConfig> repoList = this.gitScm.getRepositories();
         if (repoList.size() < 1) {
             throw new Exception("No repos found");
         }
 
         HashMap<String, URIish> commitRepoMap = new HashMap<String, URIish>();
-        BuildData buildData = build.getAction(BuildData.class);
         if (buildData == null || buildData.getLastBuiltRevision() == null) {
             logger.warning("Build data could not be found");
         } else {

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/scm/MercurialScmAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/scm/MercurialScmAdapter.java
@@ -35,23 +35,23 @@ import org.eclipse.jgit.transport.URIish;
 
 public class MercurialScmAdapter implements ScmAdapter {
 
-    private final MercurialSCM hgSCM;
-    private final Run<?, ?> build;
+    private final MercurialTagAction action;
+    private final String source;
+    private final String revision;
 
     public MercurialScmAdapter(MercurialSCM scm, Run<?, ?> build) {
-        this.hgSCM = scm;
-        this.build = build;
+        this.action = build.getAction(MercurialTagAction.class);
+        this.revision = scm.getRevision();
+        this.source = scm.getSource();
     }
 
     public Map<String, URIish> getCommitRepoMap() throws Exception {
-        String source = this.hgSCM.getSource();
         if (source == null || source.isEmpty()) {
             throw new Exception("None or multiple repos");
         }
 
         HashMap<String, URIish> commitRepoMap = new HashMap<String, URIish>();
-        MercurialTagAction action = build.getAction(MercurialTagAction.class);
-        commitRepoMap.put(action != null ? action.getId() : this.hgSCM.getRevision(), new URIish(this.hgSCM.getSource()));
+        commitRepoMap.put(action != null ? action.getId() : revision, new URIish(source));
 
         return commitRepoMap;
     }


### PR DESCRIPTION
- Updated code a small bit to get through the spotbugs.
- Added a few lines in the readme how to compile the plugin on your local machine
- Altered the pom-file to make it work with recent versions

<details><summary>Build output</summary>
<p>


[INFO] Scanning for projects...
[INFO] Artifact org.jenkins-ci.tools:maven-hpi-plugin:pom:3.32 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]  
[INFO] Artifact org.jenkins-ci.tools:maven-hpi-plugin:pom:3.32 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]  
[WARNING] The POM for org.jenkins-ci.tools:maven-hpi-plugin:jar:3.32 is missing, no dependency information available  
[INFO] Artifact org.jenkins-ci.tools:maven-hpi-plugin:jar:3.32 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]  
[INFO] Artifact org.jenkins-ci.tools:maven-hpi-plugin:jar:3.32 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]  
[WARNING] Failed to build parent project for org.jenkins-ci.plugins:bitbucket-build-status-notifier:hpi:1.4.3-SNAPSHOT  
[INFO]   
[INFO] -------< org.jenkins-ci.plugins:bitbucket-build-status-notifier >-------  
[INFO] Building Bitbucket Build Status Notifier Plugin 1.4.3-SNAPSHOT  
[INFO]   from pom.xml  
[INFO] --------------------------------[ hpi ]---------------------------------  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:validate (default-validate)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:validate-hpi (default-validate-hpi)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:initialize (default-initialize)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:generate-taglib-interface (default)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:insert-test (default-insert-test)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:test-hpl (default-test-hpl)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:resolve-test-dependencies (default-resolve-test-dependencies)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:test-runtime (default-test-runtime)'  
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.32:hpi (default-hpi)'  
[INFO]   
[INFO] --- clean:3.2.0:clean (default-clean) @ bitbucket-build-status-notifier ---  
[INFO] Deleting /usr/src/mymaven/target  
[INFO]   
[INFO] --- hpi:3.32:validate (default-validate) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- hpi:3.32:validate-hpi (default-validate-hpi) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- enforcer:3.1.0:display-info (display-info) @ bitbucket-build-status-notifier ---  
[INFO] Maven Version: 3.9.7  
[INFO] JDK Version: 21.0.3 normalized as: 21.0.3  
[INFO] Java Vendor: Eclipse Adoptium  
[INFO] OS Info: Arch: aarch64 Family: unix Name: linux Version: 6.9.6-orbstack-00147-gb0567c7c0069  
[INFO]   
[INFO] --- enforcer:3.1.0:enforce (display-info) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- enforcer:3.1.0:enforce (no-snapshots-in-release) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- hpi:3.32:initialize (default-initialize) @ bitbucket-build-status-notifier ---  
[INFO] Setting maven.compiler.release to 11  
[INFO] Setting maven.compiler.testRelease to 11  
[INFO]   
[INFO] --- gplus:1.13.1:addTestSources (test-in-groovy) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- localizer:1.31:generate (default) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- hpi:3.32:generate-taglib-interface (default) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- resources:3.3.0:resources (default-resources) @ bitbucket-build-status-notifier ---  
[INFO] Copying 5 resources  
[INFO]   
[INFO] --- compiler:3.10.1:compile (default-compile) @ bitbucket-build-status-notifier ---  
[INFO] Changes detected - recompiling the module!  
[INFO] Compiling 12 source files to /usr/src/mymaven/target/classes  
[INFO]   
[INFO] --- access-modifier-checker:1.27:enforce (default-enforce) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- hpi:3.32:insert-test (default-insert-test) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- gplus:1.13.1:generateTestStubs (test-in-groovy) @ bitbucket-build-status-notifier ---  
[INFO] No sources specified for stub generation. Skipping.  
[INFO] Generated 0 stubs.  
[INFO]   
[INFO] --- antrun:3.1.0:run (createTempDir) @ bitbucket-build-status-notifier ---  
[INFO] Executing tasks  
[INFO]     [mkdir] Created dir: /usr/src/mymaven/target/tmp  
[INFO] Executed tasks  
[INFO]   
[INFO] --- resources:3.3.0:testResources (default-testResources) @ bitbucket-build-status-notifier ---  
[INFO] skip non existing resourceDirectory /usr/src/mymaven/src/test/resources  
[INFO]   
[INFO] --- compiler:3.10.1:testCompile (default-testCompile) @ bitbucket-build-status-notifier ---  
[INFO] Changes detected - recompiling the module!  
[INFO] Compiling 1 source file to /usr/src/mymaven/target/test-classes  
[INFO]   
[INFO] --- hpi:3.32:test-hpl (default-test-hpl) @ bitbucket-build-status-notifier ---  
[INFO] Generating /usr/src/mymaven/target/test-classes/the.hpl  
[INFO]   
[INFO] --- hpi:3.32:resolve-test-dependencies (default-resolve-test-dependencies) @ bitbucket-build-status-notifier ---  
[INFO]   
[INFO] --- gplus:1.13.1:compileTests (test-in-groovy) @ bitbucket-build-status-notifier ---  
[INFO] No sources specified for compilation. Skipping.  
[INFO]   
[INFO] --- hpi:3.32:test-runtime (default-test-runtime) @ bitbucket-build-status-notifier ---  
[INFO] Setting jenkins.addOpens to --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED  
[INFO] Setting jenkins.insaneHook to --patch-module=java.base=/tmp/org-netbeans-insane-hook10754013824175105213.jar --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED  
[INFO]   
[INFO] --- surefire:3.0.0-M7:test (default-test) @ bitbucket-build-status-notifier ---  
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider  
[INFO]   
[INFO] -------------------------------------------------------  
[INFO]  T E S T S  
[INFO] -------------------------------------------------------  
Running tests for org.jenkins-ci.plugins:bitbucket-build-status-notifier:1.4.3-SNAPSHOT  
Jul 01, 2024 6:33:45 AM org.eclipse.jetty.util.log.JettyAwareLogger log  
INFO: Logging initialized @4449ms to org.eclipse.jetty.util.log.Slf4jLog  
[INFO] Running InjectedTest  
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.599 s - in InjectedTest  
[INFO]   
[INFO] Results:  
[INFO]   
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0  
[INFO]   
[INFO]   ``
[INFO] --- animal-sniffer:1.21:check (check) @ bitbucket-build-status-notifier ---  
[INFO] Signature checking is skipped.   
[INFO]   
[INFO] --- license:1.17:process (default) @ bitbucket-build-status-notifier ---  
[INFO] Generated /usr/src/mymaven/target/bitbucket-build-status-notifier/WEB-INF/licenses.xml  
[INFO]   
[INFO] --- hpi:3.32:hpi (default-hpi) @ bitbucket-build-status-notifier ---  
[INFO] Generating /usr/src/mymaven/target/bitbucket-build-status-notifier/META-INF/MANIFEST.MF  
[INFO] Checking for attached .jar artifact ...  
[INFO] Generating jar /usr/src/mymaven/target/bitbucket-build-status-notifier.jar  
[INFO] Building jar: /usr/src/mymaven/target/bitbucket-build-status-notifier.jar  
[INFO] Exploding webapp...  
[INFO] Copy webapp webResources to /usr/src/mymaven/target/bitbucket-build-status-notifier  
[INFO] Assembling webapp bitbucket-build-status-notifier in /usr/src/mymaven/target/bitbucket-build-status-notifier  
[INFO] Bundling direct dependency gson-2.10.1.jar  
[INFO] Bundling direct dependency scribe-1.3.7.jar  
[INFO] Generating hpi /usr/src/mymaven/target/bitbucket-build-status-notifier.hpi  
[INFO] Building jar: /usr/src/mymaven/target/bitbucket-build-status-notifier.hpi  
[INFO]   
[INFO] --- jar:3.2.2:test-jar (maybe-test-jar) @ bitbucket-build-status-notifier ---  
[INFO] Skipping packaging of the test-jar  
[INFO]   
[INFO] >>> spotbugs:4.7.3.0:check (spotbugs) > :spotbugs @ bitbucket-build-status-notifier >>>  
[INFO]   
[INFO] --- spotbugs:4.7.3.0:spotbugs (spotbugs) @ bitbucket-build-status-notifier ---  
[INFO] Fork Value is true  
[INFO] Done SpotBugs Analysis....  
[INFO]   
[INFO] <<< spotbugs:4.7.3.0:check (spotbugs) < :spotbugs @ bitbucket-build-status-notifier <<<  
[INFO]   
[INFO]   
[INFO] --- spotbugs:4.7.3.0:check (spotbugs) @ bitbucket-build-status-notifier ---  
[INFO] BugInstance size is 0  
[INFO] Error size is 0  
[INFO] No errors/warnings found  
[INFO]   
[INFO] --- install:3.0.1:install (default-install) @ bitbucket-build-status-notifier ---  
[INFO] Installing /usr/src/mymaven/pom.xml to /root/.m2/repository/org/jenkins-ci/plugins/bitbucket-build-status-notifier/1.4.3-SNAPSHOT/bitbucket-build-status-notifier-1.4.3-SNAPSHOT.pom  
[INFO] Installing /usr/src/mymaven/target/bitbucket-build-status-notifier.hpi to /root/.m2/repository/org/jenkins-ci/plugins/bitbucket-build-status-notifier/1.4.3-SNAPSHOT/bitbucket-build-status-notifier-1.4.3-SNAPSHOT.hpi  
[INFO] Installing /usr/src/mymaven/target/bitbucket-build-status-notifier.jar to /root/.m2/repository/org/jenkins-ci/plugins/bitbucket-build-status-notifier/1.4.3-SNAPSHOT/bitbucket-build-status-notifier-1.4.3-SNAPSHOT.jar  
[INFO] ------------------------------------------------------------------------  
[INFO] BUILD SUCCESS  
[INFO] ------------------------------------------------------------------------  
[INFO] Total time:  14.234 s  
[INFO] Finished at: 2024-07-01T06:33:56Z  
[INFO] ------------------------------------------------------------------------  
`  
</p>
</details> 
